### PR TITLE
Bugfix: missing `end` in migration

### DIFF
--- a/priv/repo/migrations/20180504172743_add_user_id_to_posts.exs
+++ b/priv/repo/migrations/20180504172743_add_user_id_to_posts.exs
@@ -7,3 +7,4 @@ defmodule Shblog.Repo.Migrations.AddUserIdToPosts do
     end
     create index(:posts, [:user_id])
   end
+end


### PR DESCRIPTION
I couldn't run the migrations until adding this `end`